### PR TITLE
drop null support

### DIFF
--- a/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
+++ b/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
@@ -140,6 +140,22 @@ public class ArrayAdapterTest {
     }
 
     @Test
+    public void addAllListContainingNull() throws Exception {
+
+        final ArrayList<String> nullList = new ArrayList<>();
+        nullList.add("A");
+        nullList.add(null);
+        nullList.add("C");
+        final TestAdapter adapter = new TestAdapter();
+        try {
+            adapter.addAll(nullList);
+            fail("did no throw");
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessageContaining("null");
+        }
+    }
+
+    @Test
     public void addAllMultiple() throws Exception {
         mAdapter.add("A");
         mAdapter.add("B");
@@ -186,6 +202,18 @@ public class ArrayAdapterTest {
         mAdapter.addAll();
         assertThat(mAdapter.getItemCount()).isEqualTo(0);
         verifyZeroInteractions(observer);
+    }
+
+    @Test
+    public void addAllVarargsListContainingNull() throws Exception {
+
+        final TestAdapter adapter = new TestAdapter();
+        try {
+            adapter.addAll("A", null, "C");
+            fail("did no throw");
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessageContaining("null");
+        }
     }
 
     @Test
@@ -316,6 +344,20 @@ public class ArrayAdapterTest {
         list.add("C");
         final TestAdapter testAdapter = new TestAdapter(list);
         assertThat(testAdapter.getItemCount()).isEqualTo(3);
+    }
+
+    @Test
+    public void constructorWithNullValueInList() throws Exception {
+        final ArrayList<String> nullList = new ArrayList<>();
+        nullList.add("A");
+        nullList.add(null);
+        nullList.add("C");
+        try {
+            final TestAdapter testAdapter = new TestAdapter(nullList);
+            fail("did no throw");
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessageContaining("null");
+        }
     }
 
     @Test
@@ -562,6 +604,18 @@ public class ArrayAdapterTest {
     }
 
     @Test
+    public void replaceItemWithNullThrows() throws Exception {
+
+        final TestAdapter adapter = new TestAdapter();
+        try {
+            adapter.replaceItem("A", null);
+            fail("did no throw");
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessageContaining("null");
+        }
+    }
+
+    @Test
     public void replaceNonExistentItem() throws Exception {
         final UserAdapter adapter = new UserAdapter();
         adapter.add(new User("A", "1"));
@@ -578,6 +632,18 @@ public class ArrayAdapterTest {
         assertThat(adapter.getItem(1)).isEqualTo(new User("B", "2"));
         assertThat(adapter.getItem(2)).isEqualTo(new User("C", "3"));
         verifyZeroInteractions(observer);
+    }
+
+    @Test
+    public void replaceNullWithItemThrow() throws Exception {
+
+        final TestAdapter adapter = new TestAdapter();
+        try {
+            adapter.replaceItem(null, "A");
+            fail("did no throw");
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessageContaining("null");
+        }
     }
 
     @Before

--- a/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
+++ b/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
@@ -367,9 +367,15 @@ public class ArrayAdapterTest {
     }
 
     @Test
-    public void getItemNotFound() throws Exception {
-        final String item = mAdapter.getItem(3);
+    public void getItemNotFoundReturnsNull() throws Exception {
+        assertThat(mAdapter.getItem(0)).isNull();
+        assertThat(mAdapter.getItem(5)).isNull();
+        assertThat(mAdapter.getItem(-1)).isNull();
 
+        mAdapter.add("A");
+        assertThat(mAdapter.getItem(0)).isEqualTo("A");
+        assertThat(mAdapter.getItem(5)).isNull();
+        assertThat(mAdapter.getItem(-1)).isNull();
     }
 
     @Test

--- a/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
+++ b/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
@@ -42,7 +42,7 @@ public class ArrayAdapterTest {
 
     private static class TestAdapter extends ArrayAdapter<String, RecyclerView.ViewHolder> {
 
-        public TestAdapter(@Nullable final List<String> objects) {
+        TestAdapter(@Nullable final List<String> objects) {
             super(objects);
         }
 
@@ -79,6 +79,7 @@ public class ArrayAdapterTest {
             this.id = id;
         }
 
+        @SuppressWarnings("SimplifiableIfStatement")
         @Override
         public boolean equals(final Object o) {
             if (this == o) {
@@ -268,6 +269,7 @@ public class ArrayAdapterTest {
         verifyNoMoreInteractions(observer);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void addNull() throws Exception {
         try {
@@ -329,7 +331,7 @@ public class ArrayAdapterTest {
     @Test
     public void constructorNull() throws Exception {
         try {
-            final TestAdapter testAdapter = new TestAdapter(null);
+            new TestAdapter(null);
             fail("did no throw");
         } catch (IllegalStateException e) {
             assertThat(e).hasMessageContaining("null");
@@ -353,7 +355,7 @@ public class ArrayAdapterTest {
         nullList.add(null);
         nullList.add("C");
         try {
-            final TestAdapter testAdapter = new TestAdapter(nullList);
+            new TestAdapter(nullList);
             fail("did no throw");
         } catch (IllegalStateException e) {
             assertThat(e).hasMessageContaining("null");
@@ -408,6 +410,7 @@ public class ArrayAdapterTest {
         verifyNoMoreInteractions(observer);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void insertNullThrows() throws Exception {
         mAdapter.add("A");
@@ -440,7 +443,7 @@ public class ArrayAdapterTest {
         assertThat(mAdapter.isItemTheSame("A", "B")).isFalse();
 
         mAdapter = new TestAdapter() {
-            @SuppressWarnings("UnnecessaryBoxing")
+            @SuppressWarnings({"UnnecessaryBoxing", "UseValueOf"})
             @Override
             public Object getItemId(@NonNull final String item) {
                 // equal id, not same object
@@ -513,6 +516,7 @@ public class ArrayAdapterTest {
         verifyZeroInteractions(observer);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void removeNull() throws Exception {
         mAdapter.add("A");
@@ -609,6 +613,7 @@ public class ArrayAdapterTest {
         verifyNoMoreInteractions(observer);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void replaceItemWithNullThrows() throws Exception {
 
@@ -640,6 +645,7 @@ public class ArrayAdapterTest {
         verifyZeroInteractions(observer);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void replaceNullWithItemThrow() throws Exception {
 

--- a/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
+++ b/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
@@ -142,7 +142,6 @@ public class ArrayAdapterTest {
 
     @Test
     public void addAllListContainingNull() throws Exception {
-
         final ArrayList<String> nullList = new ArrayList<>();
         nullList.add("A");
         nullList.add(null);
@@ -207,7 +206,6 @@ public class ArrayAdapterTest {
 
     @Test
     public void addAllVarargsListContainingNull() throws Exception {
-
         final TestAdapter adapter = new TestAdapter();
         try {
             adapter.addAll("A", null, "C");
@@ -616,7 +614,6 @@ public class ArrayAdapterTest {
     @SuppressWarnings("ConstantConditions")
     @Test
     public void replaceItemWithNullThrows() throws Exception {
-
         final TestAdapter adapter = new TestAdapter();
         try {
             adapter.replaceItem("A", null);
@@ -648,7 +645,6 @@ public class ArrayAdapterTest {
     @SuppressWarnings("ConstantConditions")
     @Test
     public void replaceNullWithItemThrow() throws Exception {
-
         final TestAdapter adapter = new TestAdapter();
         try {
             adapter.replaceItem(null, "A");
@@ -853,7 +849,6 @@ public class ArrayAdapterTest {
     @Test
     public void swap_onlyDataChanged() throws Exception {
         final UserAdapter adapter = new UserAdapter();
-
         adapter.add(new User("A", "1"));
         adapter.add(new User("B", "2"));
         adapter.add(new User("C", "3"));

--- a/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
+++ b/arrayadapter/src/androidTest/java/com/pascalwelsch/arrayadapter/ArrayAdapterTest.java
@@ -379,6 +379,18 @@ public class ArrayAdapterTest {
     }
 
     @Test
+    public void getPosition() throws Exception {
+        assertThat(mAdapter.getPosition("X")).isEqualTo(-1);
+
+        mAdapter.addAll("A", "B", "C");
+        assertThat(mAdapter.getPosition("A")).isEqualTo(0);
+        assertThat(mAdapter.getPosition("B")).isEqualTo(1);
+        assertThat(mAdapter.getPosition("C")).isEqualTo(2);
+        assertThat(mAdapter.getPosition("X")).isEqualTo(-1);
+
+    }
+
+    @Test
     public void insert() throws Exception {
         mAdapter.add("A");
         mAdapter.add("B");

--- a/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
+++ b/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
@@ -27,9 +27,11 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * Simple adapter implementation analog to {@link android.widget.ArrayAdapter} for {@link
- * android.support.v7.widget.RecyclerView}. Holds to a list of objects of type {@link T}
+ * Simple {@link RecyclerView.Adapter} implementation analog to {@link android.widget.ArrayAdapter}
+ * for {@link android.support.v7.widget.RecyclerView}. Holds to a list of objects of type {@link T}
  *
+ * @param <T>  item type (a immutable pojo works best)
+ * @param <VH> {@link RecyclerView.ViewHolder} for item {@link T}
  * @author Pascal Welsch on 04.07.14.
  *         Major update 09.05.17.
  */

--- a/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
+++ b/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
@@ -30,7 +30,8 @@ import java.util.List;
  * Simple adapter implementation analog to {@link android.widget.ArrayAdapter} for {@link
  * android.support.v7.widget.RecyclerView}. Holds to a list of objects of type {@link T}
  *
- * Created by Pascal Welsch on 04.07.14.
+ * @author Pascal Welsch on 04.07.14.
+ *         Major update 09.05.17.
  */
 @SuppressWarnings("WeakerAccess")
 public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
@@ -42,14 +43,21 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
      */
     private final Object mLock = new Object();
 
-    private List<T> mObjects;
+    private final List<T> mObjects = new ArrayList<>();
 
-    public ArrayAdapter(@Nullable final List<T> objects) {
-        mObjects = objects != null ? objects : new ArrayList<T>();
+    public ArrayAdapter(@NonNull final List<T> objects) {
+        if (objects == null) {
+            throw new IllegalStateException("null is not supported. Use an empty list.");
+        }
+
+        for (final T item : objects) {
+            requireNotNullItem(item);
+            mObjects.add(item);
+        }
     }
 
     public ArrayAdapter() {
-        this(null);
+
     }
 
     /**
@@ -57,7 +65,8 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
      *
      * @param object The object to add at the end of the array.
      */
-    public void add(@Nullable final T object) {
+    public void add(@NonNull final T object) {
+        requireNotNullItem(object);
         final int position;
         synchronized (mLock) {
             position = getItemCount();
@@ -79,7 +88,10 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
         final int position;
         synchronized (mLock) {
             position = getItemCount();
-            mObjects.addAll(collection);
+            for (final T item : collection) {
+                requireNotNullItem(item);
+                mObjects.add(item);
+            }
         }
         notifyItemRangeInserted(position, length);
     }
@@ -98,7 +110,10 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
         final int position;
         synchronized (mLock) {
             position = getItemCount();
-            Collections.addAll(mObjects, items);
+            for (final T item : items) {
+                requireNotNullItem(item);
+                mObjects.add(item);
+            }
         }
         notifyItemRangeInserted(position, length);
     }
@@ -118,8 +133,17 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
         notifyItemRangeRemoved(0, size);
     }
 
+    /**
+     * Returns the item at the specified position.
+     *
+     * @param position index of the item to return
+     * @return the item at the specified position or {@code null} when not found
+     */
     @Nullable
     public T getItem(final int position) {
+        if (position >= mObjects.size()) {
+            return null;
+        }
         return mObjects.get(position);
     }
 
@@ -136,15 +160,16 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
      * @param item for which a stable id should be generated
      * @return a identifier for the given item
      */
+    @Nullable
     public abstract Object getItemId(@NonNull T item);
 
     /**
      * Returns the position of the specified item in the array.
      *
      * @param item The item to retrieve the position of.
-     * @return The position of the specified item.
+     * @return The position of the specified item or -1 if there is no such item.
      */
-    public int getPosition(@Nullable final T item) {
+    public int getPosition(@NonNull final T item) {
         return mObjects.indexOf(item);
     }
 
@@ -154,7 +179,8 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
      * @param object The object to insert into the array.
      * @param index  The index at which the object must be inserted.
      */
-    public void insert(@Nullable T object, int index) {
+    public void insert(@NonNull T object, int index) {
+        requireNotNullItem(object);
         synchronized (mLock) {
             mObjects.add(index, object);
         }
@@ -212,14 +238,14 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
      *
      * @param object The object to remove.
      */
-    public void remove(@Nullable T object) {
+    public void remove(@NonNull T object) {
         final int position;
-        final boolean remove;
+        final boolean removed;
         synchronized (mLock) {
             position = getPosition(object);
-            remove = mObjects.remove(object);
+            removed = mObjects.remove(object);
         }
-        if (remove) {
+        if (removed) {
             notifyItemRemoved(position);
         }
     }
@@ -231,7 +257,9 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
      * @param oldObject will be removed
      * @param newObject is added only when hte old item is removed
      */
-    public void replaceItem(@Nullable final T oldObject, @Nullable final T newObject) {
+    public void replaceItem(@NonNull final T oldObject, @NonNull final T newObject) {
+        requireNotNullItem(oldObject);
+        requireNotNullItem(newObject);
 
         final int position;
         synchronized (mLock) {
@@ -272,44 +300,60 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
     }
 
     /**
-     * replaces the data with the given list
+     * Swaps the data, removes all existing data and replaces them with a new set of data. {@link
+     * DiffUtil} will coordinate to update notifications. Make sure {@link #getItemId(Object)} is
+     * implemented correctly.
      *
-     * @param newObjects new data
+     * @param newObjects new set of data
+     * @see #isContentTheSame(Object, Object)
+     * @see #isItemTheSame(Object, Object)
      */
     @SuppressWarnings("ConstantConditions")
-    public void swap(@NonNull final List<T> newObjects) {
+    public void swap(@Nullable final List<T> newObjects) {
         if (newObjects == null) {
-            throw new IllegalStateException("the new list can't be null");
+            clear();
+        } else {
+            final DiffUtil.DiffResult result = DiffUtil.calculateDiff(new DiffUtil.Callback() {
+                @Override
+                public boolean areContentsTheSame(final int oldItemPosition,
+                        final int newItemPosition) {
+                    final T oldItem = mObjects.get(oldItemPosition);
+                    final T newItem = newObjects.get(newItemPosition);
+                    return isContentTheSame(oldItem, newItem);
+                }
+
+                @Override
+                public boolean areItemsTheSame(final int oldItemPosition,
+                        final int newItemPosition) {
+                    final T oldItem = mObjects.get(oldItemPosition);
+                    final T newItem = newObjects.get(newItemPosition);
+                    return isItemTheSame(oldItem, newItem);
+                }
+
+                @Override
+                public int getNewListSize() {
+                    return newObjects.size();
+                }
+
+                @Override
+                public int getOldListSize() {
+                    return mObjects.size();
+                }
+            });
+            synchronized (mLock) {
+                mObjects.clear();
+                for (final T item : newObjects) {
+                    requireNotNullItem(item);
+                    mObjects.add(item);
+                }
+            }
+            result.dispatchUpdatesTo(this);
         }
-        DiffUtil.DiffResult result = DiffUtil.calculateDiff(new DiffUtil.Callback() {
-            @Override
-            public boolean areContentsTheSame(final int oldItemPosition,
-                    final int newItemPosition) {
-                final T oldItem = mObjects.get(oldItemPosition);
-                final T newItem = newObjects.get(newItemPosition);
-                return isContentTheSame(oldItem, newItem);
-            }
+    }
 
-            @Override
-            public boolean areItemsTheSame(final int oldItemPosition, final int newItemPosition) {
-                final T oldItem = mObjects.get(oldItemPosition);
-                final T newItem = newObjects.get(newItemPosition);
-                return isItemTheSame(oldItem, newItem);
-            }
-
-            @Override
-            public int getNewListSize() {
-                return newObjects != null ? newObjects.size() : 0;
-            }
-
-            @Override
-            public int getOldListSize() {
-                return mObjects != null ? mObjects.size() : 0;
-            }
-        });
-        synchronized (mLock) {
-            mObjects = newObjects;
+    private static void requireNotNullItem(Object o) {
+        if (o == null) {
+            throw new IllegalStateException("null items are not allowed");
         }
-        result.dispatchUpdatesTo(this);
     }
 }

--- a/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
+++ b/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
@@ -140,7 +140,7 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
      */
     @Nullable
     public T getItem(final int position) {
-        if (position >= mObjects.size()) {
+        if (position < 0 || position >= mObjects.size()) {
             return null;
         }
         return mObjects.get(position);

--- a/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
+++ b/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
@@ -49,11 +49,7 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
         if (objects == null) {
             throw new IllegalStateException("null is not supported. Use an empty list.");
         }
-
-        for (final T item : objects) {
-            requireNotNullItem(item);
-            mObjects.add(item);
-        }
+        addAll(objects);
     }
 
     public ArrayAdapter() {

--- a/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
+++ b/arrayadapter/src/main/java/com/pascalwelsch/arrayadapter/ArrayAdapter.java
@@ -45,6 +45,7 @@ public abstract class ArrayAdapter<T, VH extends RecyclerView.ViewHolder>
 
     private final List<T> mObjects = new ArrayList<>();
 
+    @SuppressWarnings("ConstantConditions")
     public ArrayAdapter(@NonNull final List<T> objects) {
         if (objects == null) {
             throw new IllegalStateException("null is not supported. Use an empty list.");


### PR DESCRIPTION
The `ArrayList` of `ListView` supports `null` values in the adapter. I copied it initially without thinking much about it. Now I think it's not useful. The support for `null` in the data set will be dropped.

Also, this PR changes the handling of `swap` and the constructor. It was possible to replace the internal data set with a list from outside. This allowed changes on the data set without notifications.
The new implementation copies the elements of the incoming list. Changes on the incoming list are therefore not reflected on the internal data. (If the items are mutable they would still change when changed outside the adapter).